### PR TITLE
Add instructions on how to setup the iso directory for building.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ This repository is dedicated to the decompilation of the PS1 game Vib-Ribbon (ãƒ
 
 ## How to build
 
+Place all the necessary executable files in the `iso` directory (e.g. `MAIN_G.EXE`) first.
+`.bin`/`.cue` files will not work, and in that case you will have to extract it manually yourself via a program such as `binwalk`
+
  1. Run `make extract` to generate the assembly files in the `asm/` directory
  1. Run `make all` to compile the binaries in the `build/` directory
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ This repository is dedicated to the decompilation of the PS1 game Vib-Ribbon (ãƒ
 
 ## How to build
 
-Place all the necessary executable files in the `iso` directory (e.g. `MAIN_G.EXE`) first.
-`.bin`/`.cue` files will not work, and in that case you will have to extract it manually yourself via a program such as `binwalk`
+Place all the necessary PSX executable files in the `iso` directory (e.g. `MAIN_G.EXE`) first.
+`.bin`/`.cue` files will not work, and in that case you will have to extract it manually from the binary yourself via a program such as `binwalk`.
 
  1. Run `make extract` to generate the assembly files in the `asm/` directory
  1. Run `make all` to compile the binaries in the `build/` directory


### PR DESCRIPTION
Currently this guide assumes that the user is capable of/has their own copy of the executables already, but it's possible that some users may not know to extract the executables from the binary data of their copy of the game. This just clarifies things a bit.