### PR TITLE
Migrate some rodata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,9 +167,9 @@ $(BUILD_DIR)/%.s.o: %.s
 $(BUILD_DIR)/%.bin.o: %.bin
 	$(LD) -r -b binary -o -Map %.map $@ $<
 
+# $(GCC) $(CC_FLAGS) $(SDATA_LIMIT) $(OPT_FLAGS) $(AS_FLAGS),$(AS_SDATA_LIMIT) $< -o $@
 $(BUILD_DIR)/%.c.o: %.c $(MASPSX_APP)
 	@$(CC_CHECK) $<
-	# $(GCC) $(CC_FLAGS) $(SDATA_LIMIT) $(OPT_FLAGS) $(AS_FLAGS),$(AS_SDATA_LIMIT) $< -o $@
 	$(CPP) $(CPP_FLAGS) $< | $(CC) $(CC_FLAGS) $(OPT_FLAGS) $(SDATA_LIMIT) | $(MASPSX) $(MASPSX_ARGS) $(AS_SDATA_LIMIT) | $(AS) $(AS_SDATA_LIMIT) -o $@
 
 SHELL = /bin/bash -e -o pipefail

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ M2C_ARGS        := -P 4
 MASPSX_DIR      := $(TOOLS_DIR)/maspsx
 MASPSX_APP      := $(MASPSX_DIR)/maspsx.py
 MASPSX          := $(PYTHON) $(MASPSX_APP)
-MASPSX_ARGS     := --expand-div --no-macro-inc
+MASPSX_ARGS     := --expand-div
 
 # flags
 SDATA_LIMIT     := -G4

--- a/bin/as
+++ b/bin/as
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-python3 $(dirname -- $0)/../tools/maspsx/maspsx.py --run-assembler --expand-div --no-macro-inc $@
+python3 $(dirname -- $0)/../tools/maspsx/maspsx.py --run-assembler --expand-div $@

--- a/config/splat.sces028.yml
+++ b/config/splat.sces028.yml
@@ -18,8 +18,10 @@ options:
   undefined_syms_auto_path:    config/undefined_syms_auto.sces028.vib-ribbon.txt
   find_file_boundaries:        yes
   use_legacy_include_asm:      no
-  migrate_rodata_to_functions: no
+  migrate_rodata_to_functions: yes
   disasm_unknown:              yes
+
+  include_macro_inc:           no # don't write macro.inc to rodata files
 
   rodata_string_guesser_level: 2 # improve string detection
 
@@ -40,8 +42,14 @@ segments:
     subalign: 4
     subsegments:
        # rodata
-      - [0x800, rodata, VideoSys]
-      - [0x8C8, rodata]
+      - [0x800, .rodata, VideoSys]
+      - [0x87C, .rodata, 5FE8]
+      - [0x914, rodata] # AudioSys
+      - [0x9E8, rodata] # InputSys
+      - [0xA6C, rodata] # MemorySys
+      - [0xC00, rodata] # FileSys
+      - [0xEA4, rodata] # InputControl
+      - [0xF74, rodata] # Movie.h
       - [0x1070, rodata]
       - [0x1810, rodata]
       - [0x3F5C, rodata]

--- a/config/splat.sces028.yml
+++ b/config/splat.sces028.yml
@@ -44,13 +44,13 @@ segments:
        # rodata
       - [0x800, .rodata, VideoSys]
       - [0x87C, .rodata, 5FE8]
-      - [0x914, rodata] # AudioSys
-      - [0x9E8, rodata] # InputSys
-      - [0xA6C, rodata] # MemorySys
+      - [0x914, .rodata, AudioSys]
+      - [0x9E8, .rodata, InputSys]
+      - [0xA44, rodata] # MemorySys
       - [0xC00, rodata] # FileSys
       - [0xEA4, rodata] # InputControl
       - [0xF74, rodata] # Movie.h
-      - [0x1070, rodata]
+      - [0x1070, rodata] # E9A0
       - [0x1810, rodata]
       - [0x3F5C, rodata]
       - [0x4264, rodata]

--- a/include/include_asm.h
+++ b/include/include_asm.h
@@ -1,9 +1,6 @@
 #ifndef INCLUDE_ASM_H
 #define INCLUDE_ASM_H
 
-#define STRINGIFY_(x) #x
-#define STRINGIFY(x) STRINGIFY_(x)
-
 #ifndef PERMUTER
 
 #ifndef INCLUDE_ASM
@@ -17,10 +14,15 @@
           "\t.set reorder\n"                                                   \
           "\t.set at\n"                                                        \
           "\t.end\t" #NAME);
-#endif
 
-// omit .global
-__asm__(".include \"macro.inc\"\n");
+#define INCLUDE_RODATA(FOLDER, NAME) \
+__asm__( \
+    ".section .rodata\n" \
+    "\t.include \""FOLDER"/"#NAME".s\"\n" \
+    ".section .text" \
+)
+
+#endif
 
 #else
 #define INCLUDE_ASM(FOLDER, NAME)

--- a/include/include_asm.h
+++ b/include/include_asm.h
@@ -26,6 +26,7 @@ __asm__( \
 
 #else
 #define INCLUDE_ASM(FOLDER, NAME)
+#define INCLUDE_RODATA(FOLDER, NAME)
 #endif
 
 #endif

--- a/src/game/5FE8.c
+++ b/src/game/5FE8.c
@@ -25,6 +25,10 @@ INCLUDE_ASM("asm/game/nonmatchings/5FE8", func_8001EBD4);
 
 INCLUDE_ASM("asm/game/nonmatchings/5FE8", func_8001EC08);
 
+INCLUDE_RODATA("asm/game/nonmatchings/5FE8", D_8001907C);
+
+INCLUDE_RODATA("asm/game/nonmatchings/5FE8", D_800190A4);
+
 INCLUDE_ASM("asm/game/nonmatchings/5FE8", func_8001EC74);
 
 INCLUDE_ASM("asm/game/nonmatchings/5FE8", func_8001ED44);

--- a/src/game/5FE8.c
+++ b/src/game/5FE8.c
@@ -8,9 +8,33 @@
 
 INCLUDE_ASM("asm/game/nonmatchings/5FE8", func_8001E7E8);
 
-INCLUDE_ASM("asm/game/nonmatchings/5FE8", func_8001E9B0);
+void func_8001E9B0(u8 arg0, UnkStruct05 *arg1) {
+    s32 tmp1;
+    s32 tmp2;
 
+    if (arg0 == 2) {
+        tmp1 = arg1->unk2;
+        tmp2 = tmp1 / 16;
+        UnkVar01 = (tmp2 * 10) + (tmp1 - (tmp2 * 16));
+    }
+}
+
+#if 0
+void func_80032518(s32, s32*);
+s32 D_8003F974;
+s32 D_8004812C; // some kind of struct?
+//
+void func_8001E9FC(u8 arg0) {
+
+    UnkVar00 = arg0 == 2;
+    if (arg0 != 2) {
+        func_80032518(D_8003F974, &D_8004812C);
+        func_800314D8(3, &D_8004812C, 0, 0);
+    }
+}
+#else
 INCLUDE_ASM("asm/game/nonmatchings/5FE8", func_8001E9FC);
+#endif
 
 INCLUDE_ASM("asm/game/nonmatchings/5FE8", func_8001EA5C);
 
@@ -29,19 +53,102 @@ INCLUDE_RODATA("asm/game/nonmatchings/5FE8", D_8001907C);
 
 INCLUDE_RODATA("asm/game/nonmatchings/5FE8", D_800190A4);
 
+#if 0
+
+typedef struct {
+    s32 unk0;
+    s32 unk4;
+} UnkStruct03; // size unknown
+
+typedef struct {
+    s32 unk0;
+    u8  pad4[0x24];
+    s32 unk28;
+    s32 unk2C;
+} UnkStruct04; // size 0x30?
+
+extern s32 D_80047F38;
+extern s32 D_80047F3C;
+extern s32 D_80047F40;
+extern s32 D_80047F44;
+extern s32 D_80047F50;
+extern s32 D_80047F54;
+extern s32 D_80047F5C;
+extern s32 D_80047F60;
+extern UnkStruct03 *D_80047F64;
+extern s32 D_80047F68;
+extern s32 D_80047F74;
+
+void func_80031E48(void);
+void func_80031374(void);
+void func_80032158(UnkStruct04*);
+u32 func_80031C40(void);
+
+void func_8001EC74(UnkStruct03 *arg0) {
+    UnkStruct04 sp10;  // struct of size 0x30?
+    s32 temp_s0;
+
+    D_80047F64 = arg0;
+
+    UnkFunc03();
+    D_80047F60 = 0;
+    D_80047F40 = 0;
+    D_80047F44 = 0;
+    CdSys__Unk01MemAdd = 0;
+    CdSys__Unk00MemAdd = 0;
+    D_80047F50 = 0;
+    D_80047F54 = 0;
+    D_80047F74 = 0;
+    D_80047F3C = -1;
+    D_80047F38 = 0;
+    D_80047F68 = 0;
+    func_80031E48();
+    func_80031374();
+
+    sp10.unk0 = 0;
+    func_80032158(&sp10);
+    VSync(4);
+    temp_s0 = (func_80031C40() >> 4) & 1;
+    if ((D_80047F64->unk0 <= 0) && (temp_s0 != 0)) {
+
+        sp10.unk28 = 1; //
+        sp10.unk2C = 0;//
+
+        D_80047F64->unk0 = 1;
+        D_80047F64->unk4 = 0;
+
+        printf("setting null home disk\n", D_80047F64, D_80047F64->unk0, D_80047F64->unk4);
+    }
+    D_80047F5C = temp_s0;
+}
+
+const char unused_string_in_5FE8[] = "CdSys::PlayTrack(): requested track out of range\n";
+#else
 INCLUDE_ASM("asm/game/nonmatchings/5FE8", func_8001EC74);
+#endif
 
 INCLUDE_ASM("asm/game/nonmatchings/5FE8", func_8001ED44);
 
 INCLUDE_ASM("asm/game/nonmatchings/5FE8", func_8001ED6C);
 
+#if 0
+void func_8001EFEC(s32 arg0) {
+    SwEnterCriticalSection();
+    if (CdSys__Unk01MemAdd != 0) {
+        printf("Assertion failed: file \"%s\", line %d\n", "C:/psj/dev/locale/game/CdSys.cpp", 0x1FF);
+        exit(1);
+    }
+    CdSys__Unk01MemAdd = arg0;
+    SwExitCriticalSection();
+}
+#else
 INCLUDE_ASM("asm/game/nonmatchings/5FE8", func_8001EFEC);
+#endif
 
-/* CdSys__Unk00 [Error when implementing]
+#if 0
 void func_8001F048(int *arg0)
 {
     SwEnterCriticalSection();
-
     if (CdSys__Unk00MemAdd)
     {
         printf("Assertion failed: file \"%s\", line %d\n", "C:/psj/dev/locale/game/CdSys.cpp", 511);
@@ -50,7 +157,8 @@ void func_8001F048(int *arg0)
     CdSys__Unk00MemAdd = arg0;
     SwExitCriticalSection();
 }
-*/
+#else
 INCLUDE_ASM("asm/game/nonmatchings/5FE8", func_8001F048);
+#endif
 
 INCLUDE_ASM("asm/game/nonmatchings/5FE8", func_8001F0A4);

--- a/src/game/AudioSys.c
+++ b/src/game/AudioSys.c
@@ -19,12 +19,16 @@ void AudioSys__QuitSpu() {
 
 INCLUDE_ASM("asm/game/nonmatchings/AudioSys", AudioSys__SetVolume);
 
+INCLUDE_RODATA("asm/game/nonmatchings/AudioSys", D_80019114);
+
+INCLUDE_RODATA("asm/game/nonmatchings/AudioSys", D_8001913C);
+
 INCLUDE_ASM("asm/game/nonmatchings/AudioSys", func_8001F1D8);
 
 INCLUDE_ASM("asm/game/nonmatchings/AudioSys", func_8001F42C);
 
 // This function seems to be configuring the audio settings (By the AudioSys__Unk06)
-void AudioSys__UnkFunc01(UnkStruct02* arg0, s16 arg1, s16 arg2, s16 arg3) 
+void AudioSys__UnkFunc01(UnkStruct02* arg0, s16 arg1, s16 arg2, s16 arg3)
 {
     AudioSys__UnkFunc06(arg1, UnkVar04, arg0->unk0, arg0->unk4, (s16) (arg0->unk4 + 1), 0, arg2, arg2, arg3);
 }
@@ -75,16 +79,16 @@ INCLUDE_ASM("asm/game/nonmatchings/AudioSys", func_8001FE34);
 void AudioSys__UnkFunc07() // Clears the UnkVar05 values
 {
     s32 i;
-    
+
     voice_bit = 0xFFFFFF; // 16777215 in decimal
     i = 0;
-    UnkVar06 = 0; 
+    UnkVar06 = 0;
     UnkVar07 = 0;
 
     while (i < 24)
     {
         UnkVar05[i] = -1;
-        i++;          
+        i++;
     }
 }
 
@@ -107,3 +111,7 @@ INCLUDE_ASM("asm/game/nonmatchings/AudioSys", func_800201C4);
 INCLUDE_ASM("asm/game/nonmatchings/AudioSys", func_800202C0);
 
 INCLUDE_ASM("asm/game/nonmatchings/AudioSys", func_8002038C);
+
+INCLUDE_RODATA("asm/game/nonmatchings/AudioSys", AudioSys__UnknownVar);
+
+INCLUDE_RODATA("asm/game/nonmatchings/AudioSys", D_8001918C);

--- a/src/game/InputSys.c
+++ b/src/game/InputSys.c
@@ -22,6 +22,10 @@ INCLUDE_ASM("asm/game/nonmatchings/InputSys", func_800207D0);
 
 void func_800208BC(void) {}
 
+INCLUDE_RODATA("asm/game/nonmatchings/InputSys", D_800191E8);
+
+INCLUDE_RODATA("asm/game/nonmatchings/InputSys", D_80019210);
+
 INCLUDE_ASM("asm/game/nonmatchings/InputSys", InputSys__alloc);
 
 INCLUDE_ASM("asm/game/nonmatchings/InputSys", func_80020920);

--- a/src/game/VideoSys.c
+++ b/src/game/VideoSys.c
@@ -21,6 +21,10 @@ void VideoSys__OnVSync()
 
 INCLUDE_ASM("asm/game/nonmatchings/VideoSys", VideoSys__Init);
 
+INCLUDE_RODATA("asm/game/nonmatchings/VideoSys", D_80019000);
+
+INCLUDE_RODATA("asm/game/nonmatchings/VideoSys", D_80019028);
+
 INCLUDE_ASM("asm/game/nonmatchings/VideoSys", VideoSys__Quit);
 
 void VideoSys__Reset()

--- a/src/game/globals.h
+++ b/src/game/globals.h
@@ -88,12 +88,17 @@ typedef struct {
     void *unk0;
 } UnkStruct01;
 
-typedef struct 
+typedef struct
 {
     s16 unk0;
     s16 unk1; // Lowers a bit without it, this variable exists
     s16 unk4;
 } UnkStruct02;
+
+typedef struct {
+  s16 unk0;
+  u8  unk2;
+} UnkStruct05;
 
 // No origin established yet
 volatile s32 UnkVar00;
@@ -110,4 +115,3 @@ extern void UnkFunc01();
 extern int  UnkFunc02();
 extern void UnkFunc04();
 extern void UnkFunc05();
-


### PR DESCRIPTION
I couldn't get the big(ger) function to match, no idea what is going on with it. The .rodata seems a bit awkward in that gcc was deduplicating strings, and I am pretty sure I needed to match all the functions that use .rodata in this file (or at least the first ones) to get it to work.

It's worth trying to match some other files that use rodata, I've just ran out of energy today.